### PR TITLE
Check for Windows and Exit.

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,11 @@ const App = ((() => {
   let themes = ''
   let program = blessed.program()
 
+  if (os.platform() === "win32") {
+    console.error("Windows is not yet supported.")
+    process.exit(1);
+  }
+  
   const files = glob.sync(path.join(__dirname, 'themes', '*.json'))
   for (var i = 0; i < files.length; i++) {
     let themeName = files[i].replace(path.join(__dirname, 'themes') + path.sep, '').replace('.json', '')


### PR DESCRIPTION
From MrRio/vtop#158

> Adding this as I NPM installed the package and found out with an error of "ps is undefined" and I couldn't exit vtop.